### PR TITLE
attempt to fix border leftover on mobile after project display collapsed

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -140,6 +140,9 @@ p {
   width: 0;
   height: 0;
 }
+.project-display.empty-display>:nth-child(n) {
+  display: none;
+}
 .project-display :nth-child(n-1) {
   margin-bottom: .75rem;
 }


### PR DESCRIPTION
I can't see how this actually looks on mobile. Chrome mobile-synthesis doesn't show the bug that this is meant to resolve.